### PR TITLE
Display adjustments

### DIFF
--- a/display.php
+++ b/display.php
@@ -77,14 +77,22 @@ function cablecast_content_display($content){
       if (empty($channel_embed_code) == false) {
         $schedule_content .= "<div class=\"wrap\">$channel_embed_code</div>";
       }
-      
-      $schedule_content .= "
-        <div class=\"schedule-title-container\">
-          <h3>Schedule For $date</h3> 
+
+      $schedule_content .= " 
+        <h3>Schedule For $date</h3> 
+        <div class=\"schedule-title-container\">  
           <div class=\"schedule-prev-next-btns\">
-            <a href=\"$prev_link\" class=\"!text-brand-accent hover:underline\">Previous</a> | <a href=\"$next_link\" class=\"!text-brand-accent hover:underline\">Next</a>
+            <a href=\"$prev_link\" class=\"!text-brand-accent hover:underline\">« Previous Day</a> | <a href=\"$next_link\" class=\"!text-brand-accent hover:underline\">Next Day »</a>
           </div>
-        </div>";
+          <div class=\"\">
+            <form action=\"\">
+              <label for=\"schedule-date\">Choose Date:</label>
+              <input type=\"date\" id=\"schedule-date\" name=\"schedule-date\" value=\"$date\">
+              <input class=\"!text-brand-accent hover:underline\" type=\"submit\">
+            </form>
+          </div>
+        </div>
+      ";
 
       $schedule_content .= "<table><thead><tr><th class=\"schedule-time\">Time</th><th class=\"schedule-show\">Show</th></tr></thead><tbody>";
       foreach($schedule_itmes as $item) {

--- a/display.php
+++ b/display.php
@@ -70,16 +70,23 @@ function cablecast_content_display($content){
       $next_date = date('Y-m-d', strtotime($date . "+1days"));
       $prev_link = add_query_arg(array('schedule_date' => $prev_date));
       $next_link = add_query_arg(array('schedule_date' => $next_date));
-
+      
       $schedule_itmes = cablecast_get_schedules($channel_id, $date);
 
-      $schedule_content = "<h3>Schedule For $date</h3>";
       $channel_embed_code = get_post_meta($post->ID, 'cablecast_channel_live_embed_code', true);
       if (empty($channel_embed_code) == false) {
         $schedule_content .= "<div class=\"wrap\">$channel_embed_code</div>";
       }
-      $schedule_content .= "<a href=\"$prev_link\">Previous</a> | <a href=\"$next_link\">Next</a>";
-      $schedule_content .= "<table><thead><tr><th>Time</th><th>Show</th></tr></thead><tbody>";
+      
+      $schedule_content .= "
+        <div class=\"schedule-title-container\">
+          <h3>Schedule For $date</h3> 
+          <div class=\"schedule-prev-next-btns\">
+            <a href=\"$prev_link\" class=\"!text-brand-accent hover:underline\">Previous</a> | <a href=\"$next_link\" class=\"!text-brand-accent hover:underline\">Next</a>
+          </div>
+        </div>";
+
+      $schedule_content .= "<table><thead><tr><th class=\"schedule-time\">Time</th><th class=\"schedule-show\">Show</th></tr></thead><tbody>";
       foreach($schedule_itmes as $item) {
         $show_link = get_post_permalink($item->show_post_id);
         if (empty($show_link)) { continue; }


### PR DESCRIPTION
Rearranged the title and prev/next buttons so they fall under the video. Also added some css classes so I could call out the right items with css for styling in the wordpress template. If these don't work, I can revert them and work with the original code.
<img width="1315" alt="Screenshot 2024-06-13 at 2 28 17 PM" src="https://github.com/trms/wp-cablecast/assets/61241785/fd24ace9-dcca-479a-9018-e14616a11d41">
