### PR TITLE
Convert dates to uct before saving in the database

### DIFF
--- a/display.php
+++ b/display.php
@@ -62,7 +62,7 @@ function cablecast_content_display($content){
       $channel_id = get_post_meta($post->ID, 'cablecast_channel_id', true);
       $schedule_content = "";
       if (empty($_GET["schedule_date"])) {
-        $date = date("Y-m-d");
+        $date = current_time('Y-m-d');
       } else {
         $date = date('Y-m-d', strtotime($_GET["schedule_date"]));
       }

--- a/includes/sync.php
+++ b/includes/sync.php
@@ -364,12 +364,14 @@ function cablecast_sync_schedule($scheduleItems) {
     $table = $wpdb->prefix . 'cablecast_schedule_items';
     $existing_row = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table WHERE schedule_item_id=%d", $item->id));
     $show = cablecast_get_show_post_by_id($item->show);
+    $run_date_time = new DateTime($item->runDateTime);
+    $run_date_time->setTimezone(new DateTimeZone('UTC'));
     if (!$show) { continue; }
     if (empty($existing_row) && $item->deleted == FALSE) {
       $wpdb->insert(
       	$table,
         	array(
-        		'run_date_time' => $item->runDateTime,
+        		'run_date_time' => $run_date_time,
         		'show_id' => $item->show,
             'show_title' => $show->post_title,
             'show_post_id' => $show->ID,
@@ -382,7 +384,7 @@ function cablecast_sync_schedule($scheduleItems) {
       $wpdb->update(
         $table,
         array(
-          'run_date_time' => $item->runDateTime,
+          'run_date_time' => $run_date_time,
           'show_id' => $item->show,
           'show_title' => $show->post_title,
           'show_post_id' => $show->ID,

--- a/theme-functions.php
+++ b/theme-functions.php
@@ -1,18 +1,43 @@
 <?php
 
 function cablecast_get_schedules($channel_id, $date_start, $date_end = NULL) {
+  // Get the WordPress site timezone
+  $timezone = get_option('timezone_string');
+
   if (empty($date_start)) {
-    $date_start = date('Y-m-d');
+    $date_start = current_time('Y-m-d');
   }
   if (empty($date_end)) {
-    $date_end = date('Y-m-d', strtotime($date_start . "+1days"));
+    $date_end = date('Y-m-d', strtotime($date_start . " +1 days"));
   }
+
+  // Convert start and end dates to DateTime objects in the site timezone
+  $date_start_dt = new DateTime($date_start, new DateTimeZone($timezone));
+  $date_end_dt = new DateTime($date_end, new DateTimeZone($timezone));
+
+  // Convert the DateTime objects to UTC
+  $date_start_dt->setTimezone(new DateTimeZone('UTC'));
+  $date_end_dt->setTimezone(new DateTimeZone('UTC'));
+
+  // Format the dates for the SQL query
+  $date_start_utc = $date_start_dt->format('Y-m-d H:i:s');
+  $date_end_utc = $date_end_dt->format('Y-m-d H:i:s');
 
   global $wpdb;
   $table = $wpdb->prefix . 'cablecast_schedule_items';
-  return $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE channel_id=%d AND run_date_time >= %s AND run_date_time < %s ORDER BY run_date_time",
+  $results = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE channel_id=%d AND run_date_time >= %s AND run_date_time < %s ORDER BY run_date_time",
     $channel_id,
-    $date_start,
-    $date_end
+    $date_start_utc,
+    $date_end_utc
   ));
+
+  // Convert the retrieved run_date_time from UTC to the site timezone
+  foreach ($results as $result) {
+    echo "Processing $result->run_date_time\n";
+    $run_date_time_utc = new DateTime($result->run_date_time, new DateTimeZone('UTC'));
+    $run_date_time_utc->setTimezone(new DateTimeZone($timezone));
+    $result->run_date_time = $run_date_time_utc->format('Y-m-d H:i:s');
+  }
+
+  return $results;
 }


### PR DESCRIPTION
On retreiving dates from the datbase, convert them to wp timezone.